### PR TITLE
theme backgroundcolor override fix

### DIFF
--- a/ThePrimeagen/init.vim
+++ b/ThePrimeagen/init.vim
@@ -110,15 +110,15 @@ call plug#end()
 
 let g:theprimeagen_colorscheme = "gruvbox"
 fun! ColorMyPencils()
-    colorscheme ayu
-    set background=dark
-
     let g:gruvbox_contrast_dark = 'hard'
     if exists('+termguicolors')
         let &t_8f = "\<Esc>[38;2;%lu;%lu;%lum"
         let &t_8b = "\<Esc>[48;2;%lu;%lu;%lum"
     endif
     let g:gruvbox_invert_selection='0'
+
+    colorscheme ayu
+    set background=dark
 
     highlight ColorColumn ctermbg=0 guibg=grey
     highlight Normal guibg=none


### PR DESCRIPTION
If these lines are on top, the background color doesn't look exactly dark. You can test it directly with `<leader> vwm` before PR, the background will be blacker. I fixed it this way.