### PR TITLE
Change install script to be more portable and expansion issues on files with spaces

### DIFF
--- a/ThePrimeagen/install
+++ b/ThePrimeagen/install
@@ -4,7 +4,7 @@ mkdir -p ~/.config/nvim/after/plugin
 mkdir -p ~/.config/nvim/lua
 
 # link wholesale
-for f in `find . -regex ".*\.vim$\|.*\.lua$"`; do
+for f in $(find . -regex ".*\.vim$\|.*\.lua$"); do
     rm -rf "$HOME/.config/nvim/$f"
     ln -s "$HOME/dotfiles/awesome-streamerrc/ThePrimeagen/$f" "$HOME/.config/nvim/$f"
 done

--- a/ThePrimeagen/install
+++ b/ThePrimeagen/install
@@ -5,7 +5,7 @@ mkdir -p ~/.config/nvim/lua
 
 # link wholesale
 for f in `find . -regex ".*\.vim$\|.*\.lua$"`; do
-    rm -rf ~/.config/nvim/$f
-    ln -s ~/dotfiles/awesome-streamerrc/ThePrimeagen/$f ~/.config/nvim/$f
+    rm -rf "$HOME/.config/nvim/$f"
+    ln -s "$HOME/dotfiles/awesome-streamerrc/ThePrimeagen/$f" "$HOME/.config/nvim/$f"
 done
 

--- a/ThePrimeagen/install
+++ b/ThePrimeagen/install
@@ -4,7 +4,7 @@ mkdir -p ~/.config/nvim/after/plugin
 mkdir -p ~/.config/nvim/lua
 
 # link wholesale
-for f in $(find . -regex ".*\.vim$\|.*\.lua$"); do
+for f in -exec $(find . -regex ".*\.vim$\|.*\.lua$"); do
     rm -rf "$HOME/.config/nvim/$f"
     ln -s "$HOME/dotfiles/awesome-streamerrc/ThePrimeagen/$f" "$HOME/.config/nvim/$f"
 done

--- a/ThePrimeagen/install
+++ b/ThePrimeagen/install
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 mkdir -p ~/.config/nvim/plugin
 mkdir -p ~/.config/nvim/after/plugin
 mkdir -p ~/.config/nvim/lua


### PR DESCRIPTION
replace '~' with $HOME, because Tilda sometimes does not expand in double quotes. 
I put double quotes around the input augment to the command. If the variable should have a space in it would have taking it as there was two augments to the command.

for esay checking if the script hold true to either posix or a specific  shell 
edit the shebang !# to /bin/sh for posix shell or /bin/bash for bash shell.
`# apt install shellcheck`
I have this specific vim remap.
```vim
noremap <leader>s :!clear && shellcheck %<CR>
```
